### PR TITLE
vLLM 0.21 / Transformers v5 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "vllm>=0.13.0,<=0.19.1",
+    "vllm>=0.13.0,<=0.21.0",
     "torch>=2.9.0",
-    "transformers>=4.56.0,<5",
+    "transformers>=4.56.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- Removes the upper bound for Transformers, since older versions of vLLM should generally pin transformers < 5 anyway, so should be safe to delegate it to them.
- Raises upper bound for vLLM to `0.21`

Tested that the bart example runs without exploding for a few versions in fresh envs.
```
uv pip install -e . vllm==0.17.0  # should pull in transformers 4.57.6
uv pip install -e . vllm==0.19.1  # should pull in transformers 5.9.0
uv pip install -e . vllm==0.21.0  # should pull in intransformers 5.9.0
```

For each of them you should get the same response
```
output:  Trump is president of the United States. The president of the United States is president of the United States
output:  the city of Paris, the city of Paris is the city of the city of Paris. The city
```

CC @dtrifiro @NickLucche 